### PR TITLE
README.md 'Crates Status' icon link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Documentation](https://img.shields.io/badge/docs-master-blue.svg)][Documentation]
 ![License](https://img.shields.io/crates/l/PROJECT.svg)
-[![Crates Status](https://img.shields.io/crates/v/PROJECT.svg)](https://crates.io/crates/PROJECT)
+[![Crates Status](https://img.shields.io/crates/v/PROJECT.svg)][Crates.io]
 
 ## License
 


### PR DESCRIPTION
Thank you for this template Ed. Good to meet you at RustConf in Albuquerque, and last year in Portland.

README.md 'Crates Status' icon link now uses the Markdown placeholder/substitution called 'Crates.io'.