### PR TITLE
README.md list indentation and no bare URLs, as per Markdown Lint VS Code extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 
 Licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 


### PR DESCRIPTION
README.md list indentation and no bare URLs, as per MarkdownLint VS Code extension.
![image](https://github.com/epage/_rust/assets/4270240/dc804380-db55-4580-be5d-b08385cb2fd7)

![image](https://github.com/epage/_rust/assets/4270240/d1aa5045-9e15-4081-adfe-a436c2b4ad14)

Suggest https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint https://github.com/DavidAnson/vscode-markdownlint.

I used to think it was too pedantic, until guess what: Someone at the last RustConf confirmed that one of its lints (that I thought was too much) is a standard accessibility rule. Wow.

By the way, this template change applied in action: https://github.com/scale-rs/test-binary-features (source code: https://github.com/scale-rs/test-binary-features/blob/main/README.md?plain=1).

Regardless of whether you pull this in or not, thank you for improving Cargo and helping Rustaceans.