### PR TITLE
chore: Ensure pre-commit gets non-system Python 

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,4 +24,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
     - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
This is needed with the ubuntu-24.04 images so that `setup-python` will
install a version of Python that the pre-commit action can install into.

See pre-commit/action#210 for more of an analysis of this.